### PR TITLE
💸 Zoopla sale adverts: skip saving duplicate content in S3.

### DIFF
--- a/zoopla-sale-advert-archive/.gitignore
+++ b/zoopla-sale-advert-archive/.gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/zoopla-sale-advert-archive/archive.js
+++ b/zoopla-sale-advert-archive/archive.js
@@ -1,0 +1,55 @@
+const AWS = require("aws-sdk"),
+  crypto = require("crypto");
+
+const s3 = new AWS.S3({
+  params: {
+    Bucket: process.env.ARCHIVE_BUCKET
+  }
+});
+
+async function archiveToS3(record) {
+  let { id, content } = record.dynamodb.NewImage;
+
+  let contentMd5 = crypto.createHash("md5")
+    .update(content.S)
+    .digest("base64");
+
+  return s3.putObject({
+    Body: content.S,
+    ContentMD5: contentMd5,
+    ContentType: "text/html",
+    Key: `details/${id.S}.html`
+  })
+    .on("success", response => {
+      console.log(`Archived ${id.S}, ${Buffer.byteLength(content.S)} bytes.`);
+    })
+    .promise();
+}
+
+function shouldArchiveToS3(record) {
+  if (!("NewImage" in record.dynamodb)) {
+    console.warn(`Archiving skipped, no new content available for ${record.dynamodb.OldImage.id.S}`);
+    return false;
+  }
+
+  let { id, content } = record.dynamodb.NewImage;
+  if (!("OldImage" in record.dynamodb)) {
+    console.log(`Archiving ${id.S}, old content not available.`);
+    return true;
+  }
+  if (record.dynamodb.OldImage.content.S != content.S) {
+    console.log(`Archiving ${id.S}, new content is different.`);
+    return true;
+  }
+
+  console.log(`Archiving ${id.S} skipped, duplicated content.`);
+  return false;
+}
+
+module.exports.handler = async event => {
+  return Promise.all(
+    event.Records
+      .filter(shouldArchiveToS3)
+      .map(archiveToS3)
+  );
+};

--- a/zoopla-sale-advert-archive/serverless.yml
+++ b/zoopla-sale-advert-archive/serverless.yml
@@ -1,0 +1,44 @@
+service: zoopla-sale-advert-archive
+frameworkVersion: '2'
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  tags:
+    SERVICE: ${self:service}
+  tracing:
+    lambda: true
+  iamManagedPolicies:
+    - arn:aws:iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy
+  iamRoleStatements:
+    - Action: s3:PutObject
+      Effect: Allow
+      Resource:
+        Fn::Join:
+          - '/'
+          - - !GetAtt ZooplaSaleAdvertsArchiveBucket.Arn
+            - '*'
+
+functions:
+  archive:
+    handler: archive.handler
+    description: |
+      Given a Zoopla sale advert snapshot: de-duplicate consecutive snapshots and archive new content only.
+    environment:
+      ARCHIVE_BUCKET: !Ref ZooplaSaleAdvertsArchiveBucket
+    events:
+      - stream:
+          type: dynamodb
+          arn: !ImportValue ZooplaSaleAdvertsIndexTableStreamArn
+    layers:
+      - arn:aws:lambda:${self:provider.region}:580247275435:layer:LambdaInsightsExtension:12
+    memorySize: 256
+
+resources:
+  Resources:
+    ZooplaSaleAdvertsArchiveBucket:
+      Type: AWS::S3::Bucket
+      DeletionPolicy: Retain
+      Properties:
+        VersioningConfiguration:
+          Status: Enabled

--- a/zoopla-sale-advert-capture/capture.js
+++ b/zoopla-sale-advert-capture/capture.js
@@ -2,53 +2,10 @@
 
 const AWS = require("aws-sdk"),
   crypto = require("crypto"),
-  https = require("https");
+  { get } = require("https.js");
 
 const env = process.env;
 const s3 = new AWS.S3();
-
-class HttpError extends Error {
-  constructor(response) {
-    super(`Download failed: HTTP ${response.statusCode}.`);
-    this.errorType = "HttpError";
-    this.httpResponseHeaders = response.headers;
-  }
-}
-
-async function httpsGet(url) {
-  return new Promise((resolve, reject) => {
-    console.log(`Downloading URL ${url}`);
-
-    https.get(
-      url,
-      response => {
-        if (response.statusCode != 200) {
-          response.resume();
-          throw new HttpError(response);
-        }
-
-        let body = "";
-        response.on(
-          "data",
-          data => {
-            body += data;
-          }
-        );
-
-        response.on(
-          "end",
-          () => {
-            console.log(`Downloaded ${Buffer.byteLength(body)} bytes.`);
-            resolve(body);
-          }
-        );
-      }
-    ).on(
-      "error",
-      reject
-    ).end();
-  });
-}
 
 async function putS3(id, body, bucket) {
   let contentMd5 = crypto.createHash("md5")
@@ -67,6 +24,6 @@ async function putS3(id, body, bucket) {
 module.exports.handler = async event => {
   let id = event.detail.id;
 
-  let body = await httpsGet(`https://www.zoopla.co.uk/for-sale/details/${id}`);
+  let body = await get(`https://www.zoopla.co.uk/for-sale/details/${id}`);
   return putS3(id, body, env.BUCKET);
 };

--- a/zoopla-sale-advert-capture/capture.js
+++ b/zoopla-sale-advert-capture/capture.js
@@ -9,9 +9,26 @@ const dynamodb = new AWS.DynamoDB({
   }
 });
 
+const NORMALIZERS = [
+
+  // A/B test
+  /ZPG\.(trackData\.ab|flags) = {.*?};/g,
+
+  // Page view count
+  /[0-9]+ page views/,
+
+  // Rental estimates
+  /£[0-9,]+ pcm/,
+
+  // Similar properties
+  /<article class="ui-property-card">.*?<\/article>/gs
+];
+
 function normalize(body) {
-  // Strip A/B test data.
-  return body.replace(/ZPG\.(trackData\.ab|flags) = {.*?};/g, '');
+  return NORMALIZERS.reduce(
+    (normalized, regex) => normalized.replace(regex, ""),
+    body
+  );
 }
 
 async function putIndexItem(id, body, now) {

--- a/zoopla-sale-advert-capture/https.js
+++ b/zoopla-sale-advert-capture/https.js
@@ -1,0 +1,46 @@
+const https = require("https");
+
+class HttpError extends Error {
+  constructor(response) {
+    super(`Download failed: HTTP ${response.statusCode}.`);
+    this.errorType = "HttpError";
+    this.httpResponseHeaders = response.headers;
+  }
+}
+
+async function get(url) {
+  return new Promise((resolve, reject) => {
+    console.log(`Downloading URL ${url}`);
+
+    https.get(
+      url,
+      response => {
+        if (response.statusCode != 200) {
+          response.resume();
+          throw new HttpError(response);
+        }
+
+        let body = "";
+        response.on(
+          "data",
+          data => {
+            body += data;
+          }
+        );
+
+        response.on(
+          "end",
+          () => {
+            console.log(`Downloaded ${Buffer.byteLength(body)} bytes.`);
+            resolve(body);
+          }
+        );
+      }
+    ).on(
+      "error",
+      reject
+    ).end();
+  });
+}
+
+module.exports.get = get;

--- a/zoopla-sale-advert-capture/serverless.yml
+++ b/zoopla-sale-advert-capture/serverless.yml
@@ -11,22 +11,17 @@ provider:
   iamManagedPolicies:
     - arn:aws:iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy
   iamRoleStatements:
-    - Action:
-        - s3:PutObject
+    - Action: dynamodb:PutItem
       Effect: Allow
-      Resource:
-        Fn::Join:
-          - '/'
-          - - !GetAtt ZooplaSaleAdvertsBucket.Arn
-            - '*'
+      Resource: !GetAtt ZooplaSaleAdvertsIndexTable.Arn
 
 functions:
   capture:
     handler: capture.handler
     description: |
-      Given a SNAPSHOT_REQUESTED event: takes a snapshot of the page, then saves it to storage.
+      Given a SNAPSHOT_REQUESTED event: takes a snapshot of the page, then indexes it.
     environment:
-      BUCKET: !Ref ZooplaSaleAdvertsBucket
+      INDEX_TABLE: !Ref ZooplaSaleAdvertsIndexTable
     events:
       - eventBridge:
           pattern:
@@ -41,14 +36,20 @@ functions:
 
 resources:
   Outputs:
-    ZooplaSaleAdvertsBucketName:
-      Value: !Ref ZooplaSaleAdvertsBucket
+    ZooplaSaleAdvertsIndexTableStreamArn:
+      Value: !GetAtt ZooplaSaleAdvertsIndexTable.StreamArn
       Export:
-        Name: ZooplaSaleAdvertsBucketName
+        Name: ZooplaSaleAdvertsIndexTableStreamArn
   Resources:
-    ZooplaSaleAdvertsBucket:
-      Type: AWS::S3::Bucket
-      DeletionPolicy: Retain
+    ZooplaSaleAdvertsIndexTable:
+      Type: AWS::DynamoDB::Table
       Properties:
-        VersioningConfiguration:
-          Status: Enabled
+        AttributeDefinitions:
+          - AttributeName: id
+            AttributeType: S
+        BillingMode: PAY_PER_REQUEST
+        KeySchema:
+          - AttributeName: id
+            KeyType: HASH
+        StreamSpecification:
+          StreamViewType: NEW_AND_OLD_IMAGES

--- a/zoopla-sale-advert-extract/extract.js
+++ b/zoopla-sale-advert-extract/extract.js
@@ -29,7 +29,7 @@ async function extractToDataLake(record) {
   );
 
   // Output structured data to logs ;)
-  console.log(snapshotItem);
+  console.log("Extracted ", snapshotItem);
 
   // Persist to data lake
   return saveDataLakeItem({

--- a/zoopla-sale-advert-extract/serverless.yml
+++ b/zoopla-sale-advert-extract/serverless.yml
@@ -12,53 +12,38 @@ provider:
     - arn:aws:iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy
   iamRoleStatements:
     - Action:
-        - s3:GetObject
-        - s3:GetObjectVersion
-      Effect: Allow
-      Resource:
-        - Fn::Join:
-          - ''
-          - - 'arn:aws:s3:::'
-            - Fn::ImportValue: ZooplaSaleAdvertsBucketName
-            - '/*'
-    - Action:
         - dynamodb:PutItem
       Effect: Allow
-      Resource: !GetAtt ZooplaSaleAdvertsTable.Arn
+      Resource: !GetAtt ZooplaSaleAdvertsDataLakeTable.Arn
 
 functions:
   extract:
     handler: extract.handler
     description: |
-      Given a Zoopla sale advert page snapshot: parse snapshot data and persist into a database table.
+      Given a Zoopla sale advert page snapshot: parse snapshot data and persist into a data lake.
     environment:
-      TABLE: !Ref ZooplaSaleAdvertsTable
+      DATA_LAKE_TABLE: !Ref ZooplaSaleAdvertsDataLakeTable
     events:
-      - s3:
-          bucket: !ImportValue ZooplaSaleAdvertsBucketName
-          event: s3:ObjectCreated:*
-          existing: true
+      - stream:
+          type: dynamodb
+          arn: !ImportValue ZooplaSaleAdvertsIndexTableStreamArn
     layers:
       - arn:aws:lambda:${self:provider.region}:580247275435:layer:LambdaInsightsExtension:12
     memorySize: 256
 
 resources:
-  Outputs:
-    ZooplaSaleAdvertsTableName:
-      Value: !Ref ZooplaSaleAdvertsTable
   Resources:
-    ZooplaSaleAdvertsTable:
+    ZooplaSaleAdvertsDataLakeTable:
       Type: AWS::DynamoDB::Table
       Properties:
         AttributeDefinitions:
           - AttributeName: id
             AttributeType: S
-          - AttributeName: creationTime
+          - AttributeName: time
             AttributeType: N
         BillingMode: PAY_PER_REQUEST
         KeySchema:
           - AttributeName: id
             KeyType: HASH
-          - AttributeName: creationTime
+          - AttributeName: time
             KeyType: RANGE
-        TableName: zoopla-sales-adverts


### PR DESCRIPTION
Saves not only unnecessary S3 storage, but more importantly S3 API calls.

Writes to a new DynamoDB table as an "index table" instead, but that
still works out cheaper than S3 - both in terms of storage and requests.

This is feasible because the content size is only ~350KB (could be
gzipped to ~50KB if the need arises in future).

In order for the de-duplication process to be effective, the content must be
normalised first, which includes stripping out dynamically generated data,
e.g. A/B test variables, page view counts and related property pages.