### PR TITLE
🔉 Serverless: set a limited log retention period.

### DIFF
--- a/advert-urls/serverless.yml
+++ b/advert-urls/serverless.yml
@@ -15,6 +15,7 @@ provider:
         - events:PutEvents
       Effect: Allow
       Resource: 'arn:aws:events:*:*:event-bus/*'
+  logRetentionInDays: 14
 
 functions:
   decode:

--- a/zoopla-sale-advert-archive/serverless.yml
+++ b/zoopla-sale-advert-archive/serverless.yml
@@ -18,6 +18,7 @@ provider:
           - '/'
           - - !GetAtt ZooplaSaleAdvertsArchiveBucket.Arn
             - '*'
+  logRetentionInDays: 14
 
 functions:
   archive:

--- a/zoopla-sale-advert-capture/serverless.yml
+++ b/zoopla-sale-advert-capture/serverless.yml
@@ -14,6 +14,7 @@ provider:
     - Action: dynamodb:PutItem
       Effect: Allow
       Resource: !GetAtt ZooplaSaleAdvertsIndexTable.Arn
+  logRetentionInDays: 14
 
 functions:
   capture:

--- a/zoopla-sale-advert-extract/serverless.yml
+++ b/zoopla-sale-advert-extract/serverless.yml
@@ -15,6 +15,7 @@ provider:
         - dynamodb:PutItem
       Effect: Allow
       Resource: !GetAtt ZooplaSaleAdvertsDataLakeTable.Arn
+  logRetentionInDays: 14
 
 functions:
   extract:

--- a/zoopla-sale-advert-schedule/serverless.yml
+++ b/zoopla-sale-advert-schedule/serverless.yml
@@ -17,6 +17,7 @@ provider:
     - Action: events:PutEvents
       Effect: Allow
       Resource: 'arn:aws:events:*:*:event-bus/*'
+  logRetentionInDays: 14
 
 functions:
   new:


### PR DESCRIPTION
To avoid runaway storage costs in CloudWatch.