### PR TITLE
💸 Restrict Lambda execution concurrency to 1.

### DIFF
--- a/advert-urls/serverless.yml
+++ b/advert-urls/serverless.yml
@@ -32,6 +32,7 @@ functions:
     layers:
       - arn:aws:lambda:${self:provider.region}:580247275435:layer:LambdaInsightsExtension:12
     memorySize: 256
+    reservedConcurrency: 1
 
 resources:
   Resources:

--- a/zoopla-sale-advert-archive/serverless.yml
+++ b/zoopla-sale-advert-archive/serverless.yml
@@ -34,6 +34,7 @@ functions:
     layers:
       - arn:aws:lambda:${self:provider.region}:580247275435:layer:LambdaInsightsExtension:12
     memorySize: 256
+    reservedConcurrency: 1
 
 resources:
   Resources:

--- a/zoopla-sale-advert-capture/serverless.yml
+++ b/zoopla-sale-advert-capture/serverless.yml
@@ -33,7 +33,7 @@ functions:
     layers:
       - arn:aws:lambda:${self:provider.region}:580247275435:layer:LambdaInsightsExtension:12
     memorySize: 256
-#    reservedConcurrency: 0      # Throttle for emergencies.
+    reservedConcurrency: 1      # Set to zero to throttle for emergencies.
 
 resources:
   Outputs:

--- a/zoopla-sale-advert-extract/serverless.yml
+++ b/zoopla-sale-advert-extract/serverless.yml
@@ -31,6 +31,7 @@ functions:
     layers:
       - arn:aws:lambda:${self:provider.region}:580247275435:layer:LambdaInsightsExtension:12
     memorySize: 256
+    reservedConcurrency: 1
 
 resources:
   Resources:

--- a/zoopla-sale-advert-schedule/serverless.yml
+++ b/zoopla-sale-advert-schedule/serverless.yml
@@ -40,6 +40,7 @@ functions:
     layers:
       - arn:aws:lambda:${self:provider.region}:580247275435:layer:LambdaInsightsExtension:12
     memorySize: 256
+    reservedConcurrency: 1
   repeat:
     handler: handler.repeatHandler
     description: |
@@ -57,6 +58,7 @@ functions:
     layers:
       - arn:aws:lambda:${self:provider.region}:580247275435:layer:LambdaInsightsExtension:12
     memorySize: 256
+    reservedConcurrency: 1
 
 resources:
   Resources:


### PR DESCRIPTION
Setting the concurrency to a low number helps to flatten spiky
workloads and minimise cold starts, as well as avoid overloading
downstream resources.

Setting a limit of 1 is admittedly a bit extreme, but a) these functions
aren't critical, and b) traffic levels are currently pretty low...