### PR TITLE
💸 Zoopla: compress DynamoDB snapshot data.

### DIFF
--- a/zoopla-sale-advert-archive/archive.js
+++ b/zoopla-sale-advert-archive/archive.js
@@ -1,4 +1,6 @@
 const AWS = require("aws-sdk"),
+  { gzip } = require("zlib"),
+  { promisify } = require("util"),
   crypto = require("crypto");
 
 const s3 = new AWS.S3({
@@ -7,23 +9,45 @@ const s3 = new AWS.S3({
   }
 });
 
-async function archiveToS3(record) {
-  let { id, content } = record.dynamodb.NewImage;
+const promisifiedGzip = promisify(gzip);
 
-  let contentMd5 = crypto.createHash("md5")
-    .update(content.S)
-    .digest("base64");
+async function archiveToS3(record) {
+  let { id, contentGzip, contentMd5 } = record.dynamodb.NewImage;
+  let content = Buffer.from(contentGzip.B, "base64");
 
   return s3.putObject({
-    Body: content.S,
-    ContentMD5: contentMd5,
+    Body: content,
+    ContentMD5: contentMd5.S,
     ContentType: "text/html",
-    Key: `details/${id.S}.html`
+    Key: `details/${id.S}.html.gz`
   })
     .on("success", response => {
-      console.log(`Archived ${id.S}, ${Buffer.byteLength(content.S)} bytes.`);
+      console.log(`Archived ${id.S}, ${Buffer.byteLength(content)} bytes.`);
     })
     .promise();
+}
+
+async function migrateRecordImage(image) {
+
+  // No migration required?
+  if ("contentMd5" in image) {
+    return image;
+  }
+
+  console.warn("LEGACY: still using uncompressed record.");
+
+  // Compress
+  let compressed = await promisifiedGzip(image.content.S);
+  delete image.content;
+  image.contentGzip = { B: compressed.toString("base64") };
+
+  // Calculate hash
+  let md5 = crypto.createHash("md5")
+    .update(compressed)
+    .digest("base64");
+  image.contentMd5 = { S: md5 };
+
+  return image;
 }
 
 function shouldArchiveToS3(record) {
@@ -32,12 +56,13 @@ function shouldArchiveToS3(record) {
     return false;
   }
 
-  let { id, content } = record.dynamodb.NewImage;
+  let { id } = record.dynamodb.NewImage;
   if (!("OldImage" in record.dynamodb)) {
     console.log(`Archiving ${id.S}, old content not available.`);
     return true;
   }
-  if (record.dynamodb.OldImage.content.S != content.S) {
+
+  if (record.dynamodb.OldImage.contentMd5.S != record.dynamodb.NewImage.contentMd5.S) {
     console.log(`Archiving ${id.S}, new content is different.`);
     return true;
   }
@@ -47,8 +72,22 @@ function shouldArchiveToS3(record) {
 }
 
 module.exports.handler = async event => {
+  let records = await Promise.all(
+    event.Records.map(
+      async record => {
+        if ("OldImage" in record.dynamodb) {
+          record.dynamodb.OldImage = await migrateRecordImage(record.dynamodb.OldImage);
+        }
+        if ("NewImage" in record.dynamodb) {
+          record.dynamodb.NewImage = await migrateRecordImage(record.dynamodb.NewImage);
+        }
+        return record;
+      }
+    )
+  );
+
   return Promise.all(
-    event.Records
+    records
       .filter(shouldArchiveToS3)
       .map(archiveToS3)
   );

--- a/zoopla-sale-advert-capture/capture.js
+++ b/zoopla-sale-advert-capture/capture.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const AWS = require("aws-sdk"),
+  { createHash } = require("crypto"),
+  { gzip } = require("zlib"),
+  { promisify } = require("util"),
   { get } = require("https.js");
 
 const dynamodb = new AWS.DynamoDB({
@@ -8,6 +11,8 @@ const dynamodb = new AWS.DynamoDB({
     TableName: process.env.INDEX_TABLE
   }
 });
+
+const promisifiedGzip = promisify(gzip);
 
 const NORMALIZERS = [
 
@@ -32,6 +37,18 @@ function normalize(body) {
 }
 
 async function putIndexItem(id, body, now) {
+  let compressed = await promisifiedGzip(body)
+    .then(
+      compressed => {
+        console.log(`Downloaded compressed to ${Buffer.byteLength(compressed)} bytes.`);
+        return compressed;
+      }
+    );
+
+  let md5 = createHash("md5")
+    .update(compressed)
+    .digest("base64");
+
   return dynamodb.putItem({
     Item: {
       id: {
@@ -40,8 +57,11 @@ async function putIndexItem(id, body, now) {
       time: {
         N: now.toString()
       },
-      content: {
-        S: body
+      contentGzip: {
+        B: compressed
+      },
+      contentMd5: {
+        S: md5
       }
     }
   }).promise();


### PR DESCRIPTION
Each uncompressed ~350KB snapshot works out to be ~350 WRUs (write
request units), and WRUs aren't part of the DynamoDB free tier, so this
turned out to be more expensive than I originally anticipated.

Compressing the data also reduces the storage footprint, although the
free tier includes 25GB per month - see https://amzn.to/2KjwbeO.

The cost of running gzip compression / decompression is an extra ~100ms
of Lambda execution time each side, which is a) still cheaper than WRUs;
and b) within the Lambda free tier anyway.

As a bonus, also archive the compressed .html.gz content directly into
S3 instead of the uncompressed .html content, saving S3 storage costs.

There's further scope to consider switching to WRUs to WCUs (i.e.
provisioned capacity in DynamoDB).