### PR TITLE
💡 AWS: disable CloudWatch Lambda Insights.

### DIFF
--- a/advert-urls/serverless.yml
+++ b/advert-urls/serverless.yml
@@ -8,8 +8,6 @@ provider:
     SERVICE: ${self:service}
   tracing:
     lambda: true
-  iamManagedPolicies:
-    - arn:aws:iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy
   iamRoleStatements:
     - Action:
         - events:PutEvents
@@ -29,8 +27,6 @@ functions:
       - stream:
           type: dynamodb
           arn: !GetAtt UrlsTable.StreamArn
-    layers:
-      - arn:aws:lambda:${self:provider.region}:580247275435:layer:LambdaInsightsExtension:12
     memorySize: 256
     reservedConcurrency: 1
 

--- a/zoopla-sale-advert-archive/serverless.yml
+++ b/zoopla-sale-advert-archive/serverless.yml
@@ -8,8 +8,6 @@ provider:
     SERVICE: ${self:service}
   tracing:
     lambda: true
-  iamManagedPolicies:
-    - arn:aws:iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy
   iamRoleStatements:
     - Action:
       - s3:DeleteObject
@@ -33,8 +31,6 @@ functions:
       - stream:
           type: dynamodb
           arn: !ImportValue ZooplaSaleAdvertsIndexTableStreamArn
-    layers:
-      - arn:aws:lambda:${self:provider.region}:580247275435:layer:LambdaInsightsExtension:12
     memorySize: 256
     reservedConcurrency: 1
 

--- a/zoopla-sale-advert-capture/serverless.yml
+++ b/zoopla-sale-advert-capture/serverless.yml
@@ -8,8 +8,6 @@ provider:
     SERVICE: ${self:service}
   tracing:
     lambda: true
-  iamManagedPolicies:
-    - arn:aws:iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy
   iamRoleStatements:
     - Action: dynamodb:PutItem
       Effect: Allow
@@ -33,8 +31,6 @@ functions:
               - prefix: property-data.
             detail-type:
               - SNAPSHOT_REQUESTED
-    layers:
-      - arn:aws:lambda:${self:provider.region}:580247275435:layer:LambdaInsightsExtension:12
     memorySize: 256
     reservedConcurrency: 1      # Set to zero to throttle for emergencies.
 

--- a/zoopla-sale-advert-extract/serverless.yml
+++ b/zoopla-sale-advert-extract/serverless.yml
@@ -8,8 +8,6 @@ provider:
     SERVICE: ${self:service}
   tracing:
     lambda: true
-  iamManagedPolicies:
-    - arn:aws:iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy
   iamRoleStatements:
     - Action:
         - dynamodb:PutItem
@@ -28,8 +26,6 @@ functions:
       - stream:
           type: dynamodb
           arn: !ImportValue ZooplaSaleAdvertsIndexTableStreamArn
-    layers:
-      - arn:aws:lambda:${self:provider.region}:580247275435:layer:LambdaInsightsExtension:12
     memorySize: 256
     reservedConcurrency: 1
 

--- a/zoopla-sale-advert-schedule/serverless.yml
+++ b/zoopla-sale-advert-schedule/serverless.yml
@@ -8,8 +8,6 @@ provider:
     SERVICE: ${self:service}
   tracing:
     lambda: true
-  iamManagedPolicies:
-    - arn:aws:iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy
   iamRoleStatements:
     - Action: dynamodb:PutItem
       Effect: Allow
@@ -37,8 +35,6 @@ functions:
               - prefix: property-data.
             detail-type:
               - ZOOPLA_SALE_ADVERT_IDENTIFIED
-    layers:
-      - arn:aws:lambda:${self:provider.region}:580247275435:layer:LambdaInsightsExtension:12
     memorySize: 256
     reservedConcurrency: 1
   repeat:
@@ -55,8 +51,6 @@ functions:
       - stream:
           type: dynamodb
           arn: !GetAtt ZooplaSaleAdvertsSchedule.StreamArn
-    layers:
-      - arn:aws:lambda:${self:provider.region}:580247275435:layer:LambdaInsightsExtension:12
     memorySize: 256
     reservedConcurrency: 1
 


### PR DESCRIPTION
Enabling CloudWatch Lambda Insights adds an additional 8 metrics per
service, which can get a bit expensive. Let's re-enable it on a
case-by-case basis instead!