### PR TITLE
🧹 JS: implement ESLint in CI pipeline.

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,10 @@
+env:
+  es2017: true
+  node: true
+extends: eslint:recommended
+parserOptions:
+  ecmaVersion: 2019
+rules:
+  no-unused-vars:
+    - error
+    - argsIgnorePattern: ^_

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: 🧹 Lint
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  eslint:
+    name: 🧹 ESLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+
+      - run: npx eslint . --ext .js

--- a/zoopla-sale-advert-archive/archive.js
+++ b/zoopla-sale-advert-archive/archive.js
@@ -17,14 +17,14 @@ async function archiveToS3(record) {
     Key: `details/${id.S}.html.gz`
   }).promise();
 
-  return putPromise.then(response => {
+  return putPromise.then(_ => {
     console.log(`Archived ${id.S}, ${Buffer.byteLength(content)} bytes.`);
 
     let deletePromise = s3.deleteObject({
       Key: `details/${id.S}.html`
     }).promise();
 
-    return deletePromise.then(response => {
+    return deletePromise.then(_ => {
       console.log(`LEGACY: ensured old archive for ${id.S} no longer exists.`);
     });
   });


### PR DESCRIPTION
At the time of writing, AWS Lambda's "Node.js 12.x" runtime seems to
support ES2019 (e.g. optional catch binding, `Object.fromEntries()`,
`globalThis`), but not ES2020 (e.g. nullish coalescing operator,
optional chaining); verified through experimentation.