### PR TITLE
🚨 GitHub: workaround for "Branch protection rule" settings bug.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   eslint:
-    name: 🧹 ESLint
+    name: ESLint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Seems like when a job's name contains an emoji character, it won't be
selectable under the "Branch protection rule" > "Require status checks
to pass before merging" list of status checks, because internally the
name of the status check gets truncated after the emoji character.