### PR TITLE
🗃 DynamoDB: enable point-in-time recovery for important tables.

### DIFF
--- a/advert-urls/serverless.yml
+++ b/advert-urls/serverless.yml
@@ -44,5 +44,7 @@ resources:
         KeySchema:
           - AttributeName: url
             KeyType: HASH
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
         StreamSpecification:
           StreamViewType: KEYS_ONLY

--- a/geographical-areas/serverless.yml
+++ b/geographical-areas/serverless.yml
@@ -42,5 +42,7 @@ resources:
         KeySchema:
           - AttributeName: polyline
             KeyType: HASH
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
         StreamSpecification:
           StreamViewType: KEYS_ONLY

--- a/zoopla-sale-advert-extract/serverless.yml
+++ b/zoopla-sale-advert-extract/serverless.yml
@@ -47,3 +47,5 @@ resources:
             KeyType: HASH
           - AttributeName: time
             KeyType: RANGE
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true


### PR DESCRIPTION
Includes "source" data (i.e. inputs) as well as "target" data (i.e.
outputs for downstream processes).

Ephemeral data sources such as schedule data aren't critical, so don't
need to be backed up.