### PR TITLE
☠ Advert URLs: add 'simple' DLQ for user errors.

### DIFF
--- a/advert-urls/serverless.yml
+++ b/advert-urls/serverless.yml
@@ -15,6 +15,9 @@ provider:
         - events:PutEvents
       Effect: Allow
       Resource: 'arn:aws:events:*:*:event-bus/*'
+    - Action: sqs:SendMessage
+      Effect: Allow
+      Resource: !GetAtt DLQ.Arn
   logRetentionInDays: 14
 
 functions:
@@ -30,10 +33,18 @@ functions:
           type: dynamodb
           arn: !GetAtt Urls.StreamArn
     memorySize: 256
+    onError: !GetAtt DLQ.Arn
     reservedConcurrency: 1
 
 resources:
   Resources:
+    DLQ:
+      Type: AWS::SQS::Queue
+      Properties:
+        ReceiveMessageWaitTimeSeconds: 20
+        Tags:
+          - Key: DLQ
+            Value: true
     Urls:
       Type: AWS::DynamoDB::Table
       Properties:


### PR DESCRIPTION
User errors won't be handled programmatically, therefore there's no need
to use a more 'complex' DLQ via Lambda's `onFailure` destination (only
'complex' in that Serverless doesn't support it out of the box...).