### PR TITLE
💸 Disable X-Ray tracing.

### DIFF
--- a/advert-urls/serverless.yml
+++ b/advert-urls/serverless.yml
@@ -8,8 +8,6 @@ provider:
   runtime: nodejs12.x
   tags:
     SERVICE: ${self:service}
-  tracing:
-    lambda: true
   iamRoleStatements:
     - Action:
         - events:PutEvents

--- a/geographical-areas/serverless.yml
+++ b/geographical-areas/serverless.yml
@@ -16,8 +16,6 @@ provider:
   runtime: nodejs12.x
   tags:
     SERVICE: ${self:service}
-  tracing:
-    lambda: true
 
 functions:
   notify:

--- a/zoopla-maps/serverless.yml
+++ b/zoopla-maps/serverless.yml
@@ -25,8 +25,6 @@ provider:
   runtime: nodejs12.x
   tags:
     SERVICE: ${self:service}
-  tracing:
-    lambda: true
 
 functions:
   dispatch:

--- a/zoopla-sale-advert-archive/serverless.yml
+++ b/zoopla-sale-advert-archive/serverless.yml
@@ -8,8 +8,6 @@ provider:
   runtime: nodejs12.x
   tags:
     SERVICE: ${self:service}
-  tracing:
-    lambda: true
   iamRoleStatements:
     - Action: s3:PutObject
       Effect: Allow

--- a/zoopla-sale-advert-capture/serverless.yml
+++ b/zoopla-sale-advert-capture/serverless.yml
@@ -8,8 +8,6 @@ provider:
   runtime: nodejs12.x
   tags:
     SERVICE: ${self:service}
-  tracing:
-    lambda: true
   iamRoleStatements:
     - Action: dynamodb:PutItem
       Effect: Allow

--- a/zoopla-sale-advert-expire/serverless.yml
+++ b/zoopla-sale-advert-expire/serverless.yml
@@ -8,8 +8,6 @@ provider:
   runtime: nodejs12.x
   tags:
     SERVICE: ${self:service}
-  tracing:
-    lambda: true
   iamRoleStatements:
     - Action: sqs:SendMessage
       Effect: Allow

--- a/zoopla-sale-advert-extract/serverless.yml
+++ b/zoopla-sale-advert-extract/serverless.yml
@@ -8,8 +8,6 @@ provider:
   runtime: nodejs12.x
   tags:
     SERVICE: ${self:service}
-  tracing:
-    lambda: true
   iamRoleStatements:
     - Action:
         - dynamodb:PutItem

--- a/zoopla-sale-advert-schedule/serverless.yml
+++ b/zoopla-sale-advert-schedule/serverless.yml
@@ -8,8 +8,6 @@ provider:
   runtime: nodejs12.x
   tags:
     SERVICE: ${self:service}
-  tracing:
-    lambda: true
   iamRoleStatements:
     - Action:
       - dynamodb:GetItem


### PR DESCRIPTION
Sampling rules cannot be configured for Lambda-X-Ray integrations; they are sampled at a fixed rate of 1r/sec (5%).

This generates costs that aren't worth the benefits.

See #52.